### PR TITLE
feat: make text responsive

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,12 +1,13 @@
 <!DOCTYPE html>
 <html lang="pt-BR">
 <head>
-<meta charset="UTF-8">
-<title>Leitura Bíblica</title>
-<link rel="stylesheet" href="style.css">
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Leitura Bíblica</title>
+  <link rel="stylesheet" href="style.css">
 </head>
 <body>
 <div id="root"></div>
-<script src="app.js"></script>
+<script src="app.js" charset="UTF-8"></script>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -1,16 +1,25 @@
 body {
-  font-family: 'Times New Roman', serif;
+  font-family: 'Georgia', serif;
   background: #F2F2F2;
   margin: 0;
 }
+
 #root {
-  width: 100%;
-  height: 100vh;
+  width: 70%;
+  max-width: 36ch;
+  min-height: 100vh;
+  margin: 0 auto;
   display: flex;
   flex-direction: column;
   justify-content: center;
   align-items: center;
   text-align: center;
+}
+
+@media (max-width: 600px) {
+  #root {
+    max-width: 20ch;
+  }
 }
 #chapter-title {
   font-size: 18px;


### PR DESCRIPTION
## Summary
- center content and size to 70% of screen
- limit desktop to ~36 characters per line and mobile to ~20
- improve readability with Georgia font and mobile viewport

## Testing
- `node --check app.js`


------
https://chatgpt.com/codex/tasks/task_e_68957390cdf88325ad92332185e3b33e