### PR TITLE
Fix accent decoding and display Bible chapters with bold header

### DIFF
--- a/app.js
+++ b/app.js
@@ -13,6 +13,7 @@ let currentVerseIndex = 0;
 const root = document.getElementById('root');
 
 function showInput() {
+  root.className = '';
   root.innerHTML = `<div>
     <label>Quantos minutos por dia?</label><br>
     <input id="minutos" type="number" min="1"><br>
@@ -124,8 +125,9 @@ function showResults(elapsed) {
 
 function startReading() {
   fetch('bíblia sagrada.txt')
-    .then(r => r.text())
-    .then(txt => {
+    .then(r => r.arrayBuffer())
+    .then(buf => {
+      const txt = new TextDecoder('iso-8859-1').decode(buf);
       chapters = parseBible(txt);
       currentChapterIndex = 0;
       currentVerseIndex = 0;
@@ -135,10 +137,10 @@ function startReading() {
 }
 
 function showCurrentVerse() {
+  root.className = 'reading';
   const ch = chapters[currentChapterIndex];
   const verse = ch.verses[currentVerseIndex];
-  root.innerHTML = `<div id="chapter-title">${formatBookName(ch.book)} ${ch.chapter}</div>
-    <div id="verse">${verse.number} ${verse.text}</div>`;
+  root.innerHTML = `<div id="chapter-title"><strong>${formatBookName(ch.book)}</strong></div><div id="verse">${verse.number} ${verse.text}</div>`;
 }
 
 function setupNavigation() {

--- a/style.css
+++ b/style.css
@@ -16,6 +16,10 @@ body {
   text-align: center;
 }
 
+#root.reading {
+  justify-content: flex-start;
+}
+
 @media (max-width: 600px) {
   #root {
     max-width: 20ch;
@@ -24,9 +28,14 @@ body {
 #chapter-title {
   font-size: 18px;
   font-weight: bold;
+  position: sticky;
+  top: 0;
+  background: #F2F2F2;
+  width: 100%;
 }
 #verse {
   margin-top: 50px;
+  word-break: break-word;
 }
 .fade {
   transition: opacity 1s;


### PR DESCRIPTION
## Summary
- Decode `bíblia sagrada.txt` using ISO-8859-1 to display accents correctly
- Show only the book name in a bold, sticky chapter title at the top of the page
- Start reading view at the top and break long verse lines within 36 characters

## Testing
- `node --check app.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68957736c3548325a0e72c480be42465