### PR TITLE
Add chapter progress bar and mobile gestures

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,6 +14,7 @@
   <button data-page="numeros">Números</button>
   <button data-page="opcoes">Opções</button>
 </nav>
+<div id="progress-container"><div id="chapter-progress"></div></div>
 <div id="root"></div>
 <script src="app.js" charset="UTF-8"></script>
 </body>

--- a/style.css
+++ b/style.css
@@ -1,9 +1,14 @@
+@font-face {
+  font-family: 'Bookerly';
+  src: url('./fontes/Bookerly.ttf') format('truetype');
+}
+
 body {
-  font-family: 'Helvetica', sans-serif;
+  font-family: 'Bookerly', serif;
   background: #F2F2F2;
   margin: 0;
   font-size: 200%;
-  padding-top: 60px;
+  padding-top: 70px;
 }
 
 #menu {
@@ -21,12 +26,33 @@ body {
   z-index: 1000;
 }
 
+body.theme-black #menu {
+  background: #333;
+}
+
+#progress-container {
+  position: fixed;
+  top: 60px;
+  left: 0;
+  width: 100%;
+  height: 10px;
+  z-index: 1000;
+  display: none;
+}
+
+#chapter-progress {
+  height: 100%;
+  width: 0;
+  background: orange;
+  transition: width 0.3s, background-color 0.3s;
+}
+
 #menu button {
   padding: 5px 10px;
   background: none;
   border: none;
   color: #FFF;
-  font-family: 'Helvetica', sans-serif;
+  font-family: 'Bookerly', serif;
   font-weight: bold;
   font-size: 15px;
   cursor: pointer;
@@ -40,7 +66,7 @@ body {
 #root {
   width: 70%;
   max-width: 36ch;
-  min-height: calc(100vh - 60px);
+  min-height: calc(100vh - 70px);
   margin: 0 auto;
   display: flex;
   flex-direction: column;
@@ -100,7 +126,7 @@ body {
   background: rgba(0, 0, 0, 0.1);
   border: none;
   padding: 10px;
-  font-family: 'Helvetica', sans-serif;
+  font-family: 'Bookerly', serif;
   font-size: 16px;
 }
 
@@ -176,8 +202,12 @@ body.theme-blue {
   }
   #verse-number {
     font-family: Verdana, sans-serif;
-    font-size: 10px;
+    font-size: 12px;
     opacity: 0.8;
     color: #000;
+    position: fixed;
+    bottom: 90px;
+    left: 50%;
+    transform: translateX(-50%);
   }
 }


### PR DESCRIPTION
## Summary
- Add Bookerly as default font and expose text size option in settings
- Show chapter progress bar with color shift from orange to blue during reading
- Support mobile gestures for verse navigation and adjust verse number placement

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check app.js`


------
https://chatgpt.com/codex/tasks/task_e_68959ff72ce083259671dcfec2645403