### PR TITLE
Add chapter progress bar and mobile gestures

### DIFF
--- a/app.js
+++ b/app.js
@@ -7,26 +7,31 @@ let currentChapterIndex = 0;
 let currentVerseIndex = 0;
 
 const root = document.getElementById('root');
+const progressContainer = document.getElementById('progress-container');
+const progressBar = document.getElementById('chapter-progress');
 
 const initSettings = getProgressData();
-applyFont(initSettings.font || 'Helvetica');
+applyFont(initSettings.font || 'Bookerly');
 applyTheme(initSettings.theme || 'theme-white');
+applyFontSize(initSettings.fontSize || '200%');
 
 if (window.matchMedia('(max-width: 600px)').matches) {
-  document.body.style.fontSize = getComputedStyle(document.body).fontSize;
+  let startX = 0;
   let startY = 0;
   document.addEventListener('touchstart', e => {
+    startX = e.touches[0].clientX;
     startY = e.touches[0].clientY;
   });
   document.addEventListener('touchend', e => {
-    const diff = startY - e.changedTouches[0].clientY;
-    let size = parseFloat(getComputedStyle(document.body).fontSize);
-    if (diff > 30) {
-      size += 2;
-    } else if (diff < -30) {
-      size = Math.max(size - 1, 10);
+    const diffX = startX - e.changedTouches[0].clientX;
+    const diffY = startY - e.changedTouches[0].clientY;
+    if (Math.abs(diffX) > Math.abs(diffY)) {
+      if (diffX > 30) {
+        nextVerse();
+      } else if (diffX < -30) {
+        prevVerse();
+      }
     }
-    document.body.style.fontSize = size + 'px';
   });
 }
 
@@ -69,6 +74,7 @@ function showBooks() {
   teardownNavigation();
   root.className = '';
   root.innerHTML = '';
+  hideProgressBar();
   const list = document.createElement('div');
   list.className = 'books';
   books.forEach((book, idx) => {
@@ -103,6 +109,8 @@ function showCurrentVerse() {
   const chapter = book.chapters[currentChapterIndex];
   const verse = chapter.verses[currentVerseIndex];
   root.innerHTML = `<div id="chapter-title" class="fade fade-out"><strong>${formatBookName(book.name)} ${chapter.number}</strong><span id="verse-number">${verse.number}</span></div><div id="verse" class="fade fade-out">${verse.text}</div>`;
+  progressContainer.style.display = 'block';
+  updateProgressBar();
   requestAnimationFrame(() => {
     root.querySelectorAll('.fade').forEach(el => el.classList.remove('fade-out'));
   });
@@ -155,6 +163,21 @@ function prevVerse() {
   });
 }
 
+function updateProgressBar() {
+  const book = books[currentBookIndex];
+  const chapter = book.chapters[currentChapterIndex];
+  const progress = (currentVerseIndex + 1) / chapter.verses.length;
+  progressBar.style.width = (progress * 100) + '%';
+  const r = Math.round(255 * (1 - progress));
+  const g = Math.round(165 * (1 - progress));
+  const b = Math.round(255 * progress);
+  progressBar.style.backgroundColor = `rgb(${r}, ${g}, ${b})`;
+}
+
+function hideProgressBar() {
+  progressContainer.style.display = 'none';
+}
+
 function fadeOut(callback) {
   const els = root.querySelectorAll('#chapter-title, #verse');
   els.forEach(el => el.classList.add('fade-out'));
@@ -176,7 +199,7 @@ function updateDaily(chars) {
 }
 
 function getProgressData() {
-  return JSON.parse(localStorage.getItem(STORAGE_KEY) || '{"books":{},"daily":{},"daysPerWeek":null,"minutesPerDay":null,"speed":null,"font":null,"theme":null}');
+  return JSON.parse(localStorage.getItem(STORAGE_KEY) || '{"books":{},"daily":{},"daysPerWeek":null,"minutesPerDay":null,"speed":null,"font":null,"theme":null,"fontSize":null}');
 }
 
 function getBookProgress(idx) {
@@ -208,6 +231,7 @@ function getTotalCharsRead() {
 
 function showNumbers() {
   teardownNavigation();
+  hideProgressBar();
   const totalCharsRead = getTotalCharsRead();
   const totalPercent = (totalCharsRead / TOTAL_CHARS) * 100;
   const data = getProgressData();
@@ -344,6 +368,7 @@ const bookMap = {
 
 function showWelcome() {
   teardownNavigation();
+  hideProgressBar();
   document.getElementById('menu').style.display = 'none';
   root.className = '';
   const state = {};
@@ -436,10 +461,12 @@ function showWelcome() {
 function showOptions() {
   teardownNavigation();
   root.className = '';
+  hideProgressBar();
   const data = getProgressData();
   root.innerHTML = `<div>
     <label>Fonte:</label>
     <select id="font-select" class="welcome-input">
+      <option value="Bookerly">Bookerly</option>
       <option value="Helvetica">Helvetica</option>
       <option value="Times New Roman">Times New Roman</option>
       <option value="Georgia">Georgia</option>
@@ -455,6 +482,8 @@ function showOptions() {
       <option value="theme-dark">Preto degradê</option>
       <option value="theme-blue">Blue</option>
     </select>
+    <label>Tamanho do texto (%):</label>
+    <input type="number" id="opt-font-size" class="welcome-input" value="${parseInt(data.fontSize) || 200}">
     <label>Dias por semana:</label>
     <input type="number" id="opt-days" class="welcome-input" max="7" value="${data.daysPerWeek || ''}">
     <label>Minutos por dia:</label>
@@ -462,11 +491,12 @@ function showOptions() {
     <button id="save-options" class="next-button">Salvar</button>
     <div id="opt-result"></div>
   </div>`;
-  document.getElementById('font-select').value = document.body.dataset.font || 'Helvetica';
+  document.getElementById('font-select').value = document.body.dataset.font || 'Bookerly';
   document.getElementById('theme-select').value = document.body.dataset.theme || 'theme-white';
   document.getElementById('save-options').onclick = () => {
     const font = document.getElementById('font-select').value;
     const theme = document.getElementById('theme-select').value;
+    const fontSize = parseInt(document.getElementById('opt-font-size').value, 10) || 200;
     const days = parseInt(document.getElementById('opt-days').value, 10) || 0;
     const mins = parseInt(document.getElementById('opt-minutes').value, 10) || 0;
     const data = getProgressData();
@@ -474,9 +504,11 @@ function showOptions() {
     data.minutesPerDay = mins;
     data.font = font;
     data.theme = theme;
+    data.fontSize = fontSize + '%';
     localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
     applyFont(font);
     applyTheme(theme);
+    applyFontSize(data.fontSize);
     const remaining = TOTAL_CHARS - getTotalCharsRead();
     const speed = data.speed || 1;
     const totalSeconds = remaining / speed;
@@ -497,6 +529,11 @@ function applyTheme(theme) {
   document.body.classList.remove('theme-white', 'theme-black', 'theme-dark', 'theme-blue');
   document.body.classList.add(theme);
   document.body.dataset.theme = theme;
+}
+
+function applyFontSize(size) {
+  document.body.style.fontSize = size;
+  document.body.dataset.fontSize = size;
 }
 
 function formatDateWritten(date) {

--- a/index.html
+++ b/index.html
@@ -14,6 +14,7 @@
   <button data-page="numeros">Números</button>
   <button data-page="opcoes">Opções</button>
 </nav>
+<div id="progress-container"><div id="chapter-progress"></div></div>
 <div id="root"></div>
 <script src="app.js" charset="UTF-8"></script>
 </body>

--- a/style.css
+++ b/style.css
@@ -1,9 +1,14 @@
+@font-face {
+  font-family: 'Bookerly';
+  src: url('./fontes/Bookerly.ttf') format('truetype');
+}
+
 body {
-  font-family: 'Helvetica', sans-serif;
+  font-family: 'Bookerly', serif;
   background: #F2F2F2;
   margin: 0;
   font-size: 200%;
-  padding-top: 60px;
+  padding-top: 70px;
 }
 
 #menu {
@@ -21,12 +26,33 @@ body {
   z-index: 1000;
 }
 
+body.theme-black #menu {
+  background: #333;
+}
+
+#progress-container {
+  position: fixed;
+  top: 60px;
+  left: 0;
+  width: 100%;
+  height: 10px;
+  z-index: 1000;
+  display: none;
+}
+
+#chapter-progress {
+  height: 100%;
+  width: 0;
+  background: orange;
+  transition: width 0.3s, background-color 0.3s;
+}
+
 #menu button {
   padding: 5px 10px;
   background: none;
   border: none;
   color: #FFF;
-  font-family: 'Helvetica', sans-serif;
+  font-family: 'Bookerly', serif;
   font-weight: bold;
   font-size: 15px;
   cursor: pointer;
@@ -40,7 +66,7 @@ body {
 #root {
   width: 70%;
   max-width: 36ch;
-  min-height: calc(100vh - 60px);
+  min-height: calc(100vh - 70px);
   margin: 0 auto;
   display: flex;
   flex-direction: column;
@@ -100,7 +126,7 @@ body {
   background: rgba(0, 0, 0, 0.1);
   border: none;
   padding: 10px;
-  font-family: 'Helvetica', sans-serif;
+  font-family: 'Bookerly', serif;
   font-size: 16px;
 }
 
@@ -176,8 +202,12 @@ body.theme-blue {
   }
   #verse-number {
     font-family: Verdana, sans-serif;
-    font-size: 10px;
+    font-size: 12px;
     opacity: 0.8;
     color: #000;
+    position: fixed;
+    bottom: 90px;
+    left: 50%;
+    transform: translateX(-50%);
   }
 }


### PR DESCRIPTION
## Summary
- Add Bookerly as default font and expose text size option in settings
- Show chapter progress bar with color shift from orange to blue during reading
- Support horizontal swipe navigation on mobile while ignoring vertical swipes

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check app.js`


------
https://chatgpt.com/codex/tasks/task_e_68959ff72ce083259671dcfec2645403