### PR TITLE
Add read theme and mobile reading improvements

### DIFF
--- a/style.css
+++ b/style.css
@@ -76,7 +76,7 @@ body.theme-black #menu {
 }
 
 #root.reading {
-  justify-content: flex-start;
+  justify-content: center;
 }
 
 @media (max-width: 600px) {
@@ -91,6 +91,18 @@ body.theme-black #menu {
   top: 135px;
   margin-top: 75px;
   display: inline-block;
+}
+#chapter-swipe {
+  position: fixed;
+  top: 70px;
+  left: 0;
+  width: 100%;
+  height: 60px;
+  background: rgba(0, 0, 0, 0);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1000;
 }
 #verse {
   margin-top: 50px;
@@ -163,6 +175,19 @@ body.theme-blue {
   color: #FFF;
 }
 
+body.theme-read {
+  background: #FFFBF7;
+  color: #706761;
+}
+
+body.theme-read #menu {
+  background: #706761;
+}
+
+body.theme-read #chapter-progress {
+  background: #DECCC0;
+}
+
 #verse-number {
   display: block;
   margin-top: 10px;
@@ -196,9 +221,10 @@ body.theme-blue {
   }
   #chapter-title {
     font-family: Verdana, sans-serif;
-    font-size: 18px;
+    font-size: 36px;
     opacity: 1;
     margin-top: 20px;
+    transform: translateY(-25px);
   }
   #verse-number {
     font-family: Verdana, sans-serif;


### PR DESCRIPTION
## Summary
- center verse block in reading mode and enlarge chapter title
- add transparent swipe box to change chapters with horizontal gestures
- introduce "read" theme with custom colors for background, text, menu, and progress bar

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6895a7769330832589340505f1ad78d8