### PR TITLE
Improve mobile reading layout and scrolling

### DIFF
--- a/app.js
+++ b/app.js
@@ -14,6 +14,7 @@ const initSettings = getProgressData();
 applyFont(initSettings.font || 'Bookerly');
 applyTheme(initSettings.theme || 'theme-white');
 applyFontSize(initSettings.fontSize || '200%');
+disableScroll();
 
 if (window.matchMedia('(max-width: 600px)').matches) {
   let startX = 0;
@@ -67,6 +68,7 @@ fetch('bíblia sagrada.txt')
 
 function showBooks() {
   teardownNavigation();
+  enableScroll();
   root.className = '';
   root.innerHTML = '';
   hideProgressBar();
@@ -99,6 +101,7 @@ function openBook(idx) {
 }
 
 function showCurrentVerse() {
+  disableScroll();
   root.className = 'reading';
   const book = books[currentBookIndex];
   const chapter = book.chapters[currentChapterIndex];
@@ -270,6 +273,7 @@ function getTotalCharsRead() {
 
 function showNumbers() {
   teardownNavigation();
+  disableScroll();
   hideProgressBar();
   const totalCharsRead = getTotalCharsRead();
   const totalPercent = (totalCharsRead / TOTAL_CHARS) * 100;
@@ -407,6 +411,7 @@ const bookMap = {
 
 function showWelcome() {
   teardownNavigation();
+  disableScroll();
   hideProgressBar();
   document.getElementById('menu').style.display = 'none';
   root.className = '';
@@ -499,6 +504,7 @@ function showWelcome() {
 
 function showOptions() {
   teardownNavigation();
+  disableScroll();
   root.className = '';
   hideProgressBar();
   const data = getProgressData();
@@ -574,6 +580,14 @@ function applyTheme(theme) {
 function applyFontSize(size) {
   document.body.style.fontSize = size;
   document.body.dataset.fontSize = size;
+}
+
+function disableScroll() {
+  document.body.style.overflow = 'hidden';
+}
+
+function enableScroll() {
+  document.body.style.overflowY = 'auto';
 }
 
 function formatDateWritten(date) {

--- a/style.css
+++ b/style.css
@@ -9,6 +9,7 @@ body {
   margin: 0;
   font-size: 200%;
   padding-top: 70px;
+  overflow: hidden;
 }
 
 #menu {
@@ -105,8 +106,10 @@ body.theme-black #menu {
   z-index: 1000;
 }
 #verse {
-  margin-top: 50px;
+  margin: 50px 20px 0;
   word-break: break-word;
+  text-align: justify;
+  hyphens: auto;
 }
 .books {
   display: flex;
@@ -219,15 +222,16 @@ body.theme-read #chapter-progress {
   body {
     font-size: 140%;
   }
+  #chapter-swipe {
+    top: 100px;
+  }
   #chapter-title {
-    font-family: Verdana, sans-serif;
     font-size: 36px;
     opacity: 1;
     margin-top: 20px;
     transform: translateY(-25px);
   }
   #verse-number {
-    font-family: Verdana, sans-serif;
     font-size: 12px;
     opacity: 0.8;
     color: #000;


### PR DESCRIPTION
## Summary
- Lower mobile chapter header box by 30px and let its font follow user options
- Add 20px side margins and justification to verse text blocks
- Disable page scrolling except on the "Livros" list

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6895b6d0280883258c7f78943320d841