### PR TITLE
Adjust mobile reading layout and footer verse number

### DIFF
--- a/style.css
+++ b/style.css
@@ -192,8 +192,12 @@ body.theme-read #chapter-progress {
 }
 
 #verse-number {
-  display: block;
-  margin-top: 10px;
+  position: fixed;
+  bottom: 10px;
+  left: 50%;
+  transform: translateX(-50%);
+  font-size: 12px;
+  opacity: 0.8;
 }
 
 #daily-circle {
@@ -231,13 +235,8 @@ body.theme-read #chapter-progress {
     margin-top: 20px;
     transform: translateY(-25px);
   }
-  #verse-number {
-    font-size: 12px;
-    opacity: 0.8;
-    color: #000;
-    position: fixed;
-    bottom: 90px;
-    left: 50%;
-    transform: translateX(-50%);
+  #verse {
+    margin: 120px 20px 0;
+    text-align: center;
   }
 }


### PR DESCRIPTION
## Summary
- Add spacing and centering for verse text on mobile, positioning the first line 30px below the swipe area
- Anchor verse number at the footer for both mobile and desktop

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6895bfe2307883259cad3b03fa0eadf7