### PR TITLE
Use fade transitions and new gestures for Bible reader

### DIFF
--- a/style.css
+++ b/style.css
@@ -149,15 +149,15 @@ body.theme-black #menu {
   width: 100%;
 }
 
-.book-item {
-  display: flex;
-  justify-content: space-between;
-  padding: 10px;
-  border-radius: 4px;
-  cursor: pointer;
-  background: rgba(0, 0, 0, 0.2);
-  font-size: 50%;
-}
+  .book-item {
+    display: flex;
+    justify-content: space-between;
+    padding: 10px;
+    border-radius: 4px;
+    cursor: pointer;
+    background: rgba(0, 0, 0, 0.2);
+    font-size: 70%;
+  }
 
 .book-title {
   margin-left: 20px;
@@ -168,9 +168,9 @@ body.theme-black #menu {
   margin-right: 20px;
   text-align: right;
 }
-.fade {
-  transition: opacity 1s;
-}
+  .fade {
+    transition: opacity 0.477s;
+  }
 
 .fade-out {
   opacity: 0;


### PR DESCRIPTION
## Summary
- Replace sliding verse animations with 477ms fade effects and fade in all page changes
- Tap anywhere to advance verses, swipe or double tap chapter area to navigate chapters, and signal end-of-book with opacity flash
- Increase book list text size by 40%

## Testing
- `node --check app.js`


------
https://chatgpt.com/codex/tasks/task_e_6896864310688325b295bc18495d89d7