### PR TITLE
Refine reading plan workflow and desktop layout

### DIFF
--- a/style.css
+++ b/style.css
@@ -102,7 +102,9 @@ body.theme-black #menu {
 }
 
 #root.welcome {
-  justify-content: flex-start;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
 }
 
 @media (max-width: 600px) {
@@ -163,6 +165,17 @@ body.theme-black #menu {
 .book-percent {
   margin-right: 20px;
   text-align: right;
+}
+
+.testament-title {
+  font-size: 170%;
+  font-weight: bold;
+  text-align: center;
+}
+
+.testament-title.nt {
+  margin-top: 50px;
+  margin-bottom: 50px;
 }
   .fade {
     transition: opacity 0.477s;
@@ -299,5 +312,14 @@ body.theme-read #chapter-progress {
   #verse-container {
     text-align: center;
     margin-top: 150px;
+  }
+}
+
+@media (min-width: 601px) {
+  #root.reading {
+    align-items: center;
+  }
+  #root.reading #verse-container {
+    text-align: center;
   }
 }


### PR DESCRIPTION
## Summary
- Hide book percentages until a reading plan is started and split book list into Old and New Testament sections
- Simplify verse navigation, add chapter control via arrow keys, and allow marking books as read
- Add reading plan launcher in numbers menu with detailed stats and enlarge/center text on desktop

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check app.js`

------
https://chatgpt.com/codex/tasks/task_e_6896a6ac3ad883259b03181d767e060b